### PR TITLE
Add Terraform S3+Lambda setup with CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: eu-west-2
+      - run: terraform init
+        working-directory: terraform
+      - run: terraform apply -auto-approve
+        working-directory: terraform

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,0 +1,23 @@
+name: Destroy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: eu-west-2
+      - run: terraform init
+        working-directory: terraform
+      - run: terraform destroy -auto-approve
+        working-directory: terraform

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Terraform files
+*.tfstate
+*.tfstate.*
+.terraform/
+*.zip
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# openai-with-aws-test5
+# AWS Terraform Example
+
+This repository provisions an S3 bucket and a Lambda function behind an API Gateway using Terraform. GitHub Actions deploys the infrastructure on merges to the `main` branch and can tear it down manually.
+
+## Infrastructure
+
+- **S3 Bucket**: `ontoscale-create-with-openai-codex`
+- **Terraform Backend**: `arn:aws:s3:::ontoscale-terraform-backend`
+- **Lambda**: Python function creating a file in the bucket.
+- **API Gateway**: HTTP endpoint invoking the Lambda.
+
+## GitHub Actions
+
+`deploy.yml` runs on pushes to `main` and applies the Terraform configuration. `destroy.yml` can be triggered manually to run `terraform destroy`.
+
+Both workflows assume the role provided in the `AWS_ROLE` secret using GitHub OIDC.
+
+## Usage
+
+To deploy locally:
+
+```bash
+cd terraform
+terraform init
+terraform apply
+```
+
+To destroy:
+
+```bash
+cd terraform
+terraform destroy
+```

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/lambda/handler.py
+++ b/terraform/lambda/handler.py
@@ -1,0 +1,15 @@
+import os
+import json
+import boto3
+from datetime import datetime
+
+s3 = boto3.client('s3')
+BUCKET_NAME = os.environ.get('BUCKET_NAME')
+
+def lambda_handler(event, context):
+    key = f"lambda-{datetime.utcnow().isoformat()}.txt"
+    s3.put_object(Bucket=BUCKET_NAME, Key=key, Body=b"Created by lambda")
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"message": "File created", "key": key})
+    }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,116 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  backend "s3" {
+    bucket = "ontoscale-terraform-backend"
+    key    = "openai-with-aws-test5/terraform.tfstate"
+    region = "eu-west-2"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket        = "ontoscale-create-with-openai-codex"
+  force_destroy = true
+}
+
+# IAM role for Lambda
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "ontoscale-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "lambda_s3" {
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.bucket.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_s3" {
+  name   = "lambda-s3-put"
+  role   = aws_iam_role.lambda_role.id
+  policy = data.aws_iam_policy_document.lambda_s3.json
+}
+
+resource "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda"
+  output_path = "${path.module}/lambda.zip"
+}
+
+resource "aws_lambda_function" "create_file" {
+  function_name    = "create_file_lambda"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "handler.lambda_handler"
+  runtime          = "python3.11"
+  filename         = archive_file.lambda_zip.output_path
+  source_code_hash = filebase64sha256(archive_file.lambda_zip.output_path)
+  environment {
+    variables = {
+      BUCKET_NAME = aws_s3_bucket.bucket.bucket
+    }
+  }
+}
+
+resource "aws_apigatewayv2_api" "http_api" {
+  name          = "create-file-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.create_file.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*"
+}
+
+resource "aws_apigatewayv2_integration" "lambda_integration" {
+  api_id                 = aws_apigatewayv2_api.http_api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.create_file.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "default_route" {
+  api_id    = aws_apigatewayv2_api.http_api.id
+  route_key = "ANY /"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda_integration.id}"
+}
+
+resource "aws_apigatewayv2_stage" "api_stage" {
+  api_id      = aws_apigatewayv2_api.http_api.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.bucket.bucket
+}
+
+output "api_endpoint" {
+  value = aws_apigatewayv2_api.http_api.api_endpoint
+}


### PR DESCRIPTION
## Summary
- add Terraform config for S3 bucket, Lambda and API Gateway
- create Python Lambda that writes to the S3 bucket
- set up deploy and destroy GitHub Actions workflows
- document usage and workflows in README

## Testing
- `terraform fmt -recursive terraform`
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68768460244c8331ae3ec060556f98b3