### PR TITLE
Fix S3 backend region

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provisions an S3 bucket and a Lambda function behind an API Gate
 ## Infrastructure
 
 - **S3 Bucket**: `ontoscale-create-with-openai-codex`
-- **Terraform Backend**: `arn:aws:s3:::ontoscale-terraform-backend`
+- **Terraform Backend**: `arn:aws:s3:::ontoscale-terraform-backend` (region `us-east-1`)
 - **Lambda**: Python function creating a file in the bucket.
 - **API Gateway**: HTTP endpoint invoking the Lambda.
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
   backend "s3" {
     bucket = "ontoscale-terraform-backend"
     key    = "openai-with-aws-test5/terraform.tfstate"
-    region = "eu-west-2"
+    region = "us-east-1"
   }
 }
 


### PR DESCRIPTION
## Summary
- fix S3 backend region to avoid region mismatch
- document backend region in README

## Testing
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_687685c56904833183eb740fa87784d4